### PR TITLE
No cost checkout

### DIFF
--- a/cartconditions/Tax.php
+++ b/cartconditions/Tax.php
@@ -35,6 +35,10 @@ class Tax extends CartCondition
         // only calculate taxes if enabled
         if (!$this->taxMode OR !$this->taxRate)
             return FALSE;
+
+        // don't calculate tax if value is 0
+        if ($this->calculatedValue <= 0)
+            return FALSE;
     }
 
     public function getActions()

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -142,7 +142,7 @@ class Checkout extends BaseComponent
     {
         $order = $this->getOrder();
 
-        return $order->order_total > 0
+        return $order->order_total >= 0
             ? $this->orderManager->getPaymentGateways() : [];
     }
 


### PR DESCRIPTION
If such coupon exists that it discounts 100% off of an item and global tax_mode is enabled, the tax is still applied even though the post-discount price is 0.
Example of how it works now: 
> Cost of item 1 is $2.45
> Applied coupon code '100off' so it's discounted by $2.45
> Subtotal is $0
> Tax is still $2.45 * taxRate
> Order Total becomes $0.16 if tax rate was 6.6%


Since priority of coupon is 200 it'll go first so this should fix that if calculatedValue is 0 then tax is not applied.

Another thing is when Payment Gateways are not selected, Cart doesn't allow it to checkout so even if the order_total is 0, show the Payment Gateways.