### PR TITLE
Fix bug in status listener

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -190,7 +190,7 @@ class Extension extends BaseExtension
 
     protected function bindOrderStatusEvent()
     {
-        Event::listen('admin.statusHistory.beforeAddStatus', function ($model, $object, $statusId, $previousStatus) {
+        Event::listen('admin.statusHistory.beforeAddStatus', function ($emitter, $model, $object, $statusId, $previousStatus) {
             if (!$object instanceof Orders_model)
                 return;
 

--- a/Extension.php
+++ b/Extension.php
@@ -190,11 +190,8 @@ class Extension extends BaseExtension
 
     protected function bindOrderStatusEvent()
     {
-        Event::listen('admin.statusHistory.beforeAddStatus', function ($emitter, $model, $object, $statusId, $previousStatus) {
+        Event::listen('admin.statusHistory.beforeAddStatus', function ($model, $object, $statusId, $previousStatus) {
             if (!$object instanceof Orders_model)
-                return;
-
-            if (Status_history_model::alreadyExists($object, $statusId))
                 return;
 
             Event::fire('igniter.cart.beforeAddOrderStatus', [$model, $object, $statusId, $previousStatus], TRUE);

--- a/Extension.php
+++ b/Extension.php
@@ -3,7 +3,6 @@
 namespace Igniter\Cart;
 
 use Admin\Models\Orders_model;
-use Admin\Models\Status_history_model;
 use Auth;
 use Cart;
 use Config;


### PR DESCRIPTION
As we are using long args (https://github.com/tastyigniter/flame/blob/197fdcf3b2f350cc0918cb7ac225b4fef6a5ecde/src/Traits/EventEmitter.php#L196), the first param is added twice (so $emitter and $model are the same). Either we fix here, or fix in Status_history_model.

My follow up question is why do we care about 
```
          if (Status_history_model::alreadyExists($object, $statusId))
                return;
```

if the status changes back to a previous one should the customer not be notified?