### PR TITLE
Fix quantity count when validating menu option

### DIFF
--- a/classes/CartManager.php
+++ b/classes/CartManager.php
@@ -382,7 +382,7 @@ class CartManager
             ));
         }
 
-        if ('quantity' == $menuOption->getDisplayTypeAttribute()) {
+        if ('quantity' == $menuOption->display_type) {
             $countSelected = array_reduce($selectedValues, function ($qty, $selectedValue) { return $qty + $selectedValue['qty']; });
         } else {
             $countSelected = count($selectedValues);

--- a/classes/CartManager.php
+++ b/classes/CartManager.php
@@ -310,7 +310,7 @@ class CartManager
     public function validateMenuItem(Menus_model $menuItem)
     {
         // if menu mealtime is enabled and menu is outside mealtime
-        if (!$menuItem->isAvailable()) {
+        if (!$menuItem->isAvailable($this->location->orderDateTime())) {
             throw new ApplicationException(
                 sprintf(
                     lang('igniter.cart::default.alert_menu_not_within_mealtimes'),

--- a/classes/CartManager.php
+++ b/classes/CartManager.php
@@ -310,7 +310,7 @@ class CartManager
     public function validateMenuItem(Menus_model $menuItem)
     {
         // if menu mealtime is enabled and menu is outside mealtime
-        if (!$menuItem->isAvailable($this->location->orderDateTime())) {
+        if (!$menuItem->isAvailable()) {
             throw new ApplicationException(
                 sprintf(
                     lang('igniter.cart::default.alert_menu_not_within_mealtimes'),
@@ -382,7 +382,12 @@ class CartManager
             ));
         }
 
-        $countSelected = count($selectedValues);
+        if ('quantity' == $menuOption->getDisplayTypeAttribute()) {
+            $countSelected = array_reduce($selectedValues, function($qty, $selectedValue) { return $qty + $selectedValue['qty']; });
+        } else {
+            $countSelected = count($selectedValues);
+        }
+
         if ($menuOption->min_selected > 0 OR $menuOption->max_selected > 0) {
             if (!($countSelected >= $menuOption->min_selected AND $countSelected <= $menuOption->max_selected)) {
                 throw new ApplicationException(sprintf(

--- a/classes/CartManager.php
+++ b/classes/CartManager.php
@@ -383,7 +383,7 @@ class CartManager
         }
 
         if ('quantity' == $menuOption->getDisplayTypeAttribute()) {
-            $countSelected = array_reduce($selectedValues, function($qty, $selectedValue) { return $qty + $selectedValue['qty']; });
+            $countSelected = array_reduce($selectedValues, function ($qty, $selectedValue) { return $qty + $selectedValue['qty']; });
         } else {
             $countSelected = count($selectedValues);
         }


### PR DESCRIPTION
When the quantity option type is used with a min or max quantity defined, the validating wasn't working.
The count was always the count of the options, because the quantity option returns a multidimensional array, where other option types return an array of selected values.
(I may submit more pull requests in the future as I'm starting to use your system, please tell me if you'd like that I open an issue first next time, or if you have some coding standard you'd like I use)