### PR TITLE
Fix random code glitch on mail templates

### DIFF
--- a/views/mail/order.blade.php
+++ b/views/mail/order.blade.php
@@ -65,8 +65,7 @@ Your {order_type} order **{order_number}** has been received and will be with yo
     @if(!empty($order_menus))
         @foreach($order_menus as $order_menu)
             <tr>
-                <td>{{ $order_menu['menu_quantity'] }} x {{ $order_menu['menu_name'] }}
-                    <br>{!! $order_menu['menu_options'] !!}<br>{!! $order_menu['menu_comment'] !!}</td>
+                <td>{{ $order_menu['menu_quantity'] }} x {{ $order_menu['menu_name'] }}<br>{!! $order_menu['menu_options'] !!}<br>{!! $order_menu['menu_comment'] !!}</td>
                 <td align="right">{{ $order_menu['menu_price'] }}</td>
                 <td align="right">{{ $order_menu['menu_subtotal'] }}</td>
             </tr>

--- a/views/mail/order_alert.blade.php
+++ b/views/mail/order_alert.blade.php
@@ -56,8 +56,7 @@ Restaurant: {location_name}
     @if(!empty($order_menus))
         @foreach($order_menus as $order_menu)
             <tr>
-                <td>{{ $order_menu['menu_quantity'] }} x {{ $order_menu['menu_name'] }}
-                    <br>{!! $order_menu['menu_options'] !!}<br>{!! $order_menu['menu_comment'] !!}</td>
+                <td>{{ $order_menu['menu_quantity'] }} x {{ $order_menu['menu_name'] }}<br>{!! $order_menu['menu_options'] !!}<br>{!! $order_menu['menu_comment'] !!}</td>
                 <td align="right">{{ $order_menu['menu_price'] }}</td>
                 <td align="right">{{ $order_menu['menu_subtotal'] }}</td>
             </tr>


### PR DESCRIPTION
On new installs when there is no menu options we've noticed the table displays as code after the first line, and this change fixes it. No idea why, but one of my team discovered this fix by chance. 🤷🏻‍♂️