### PR TITLE
Allow checkout rules to be extended through events

### DIFF
--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -305,6 +305,10 @@ class Checkout extends BaseComponent
             $namedRules[] = ['address.postcode', 'lang:igniter.cart::default.checkout.label_postcode', 'string'];
             $namedRules[] = ['address.country_id', 'lang:igniter.cart::default.checkout.label_country', 'sometimes|required|integer'];
         }
+        
+        $mergeRules = $this->fireSystemEvent('igniter.cart.createCheckoutRules');
+        if (count($mergeRules))
+            $namedRules = array_merge($mergeRules, $namedRules);
 
         return $namedRules;
     }


### PR DESCRIPTION
Allows devs/extensions to add checkout validation for extra fields.

When used in combination with Orders_model::extend(function($model) { $model->addFillable([ 'x' ]); and custom theme partials in an extension this means fields can be added quite easily.