### PR TITLE
Fix bugs

### DIFF
--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -290,7 +290,7 @@ class Checkout extends BaseComponent
             ['first_name', 'lang:igniter.cart::default.checkout.label_first_name', 'required|between:1,48'],
             ['last_name', 'lang:igniter.cart::default.checkout.label_last_name', 'required|between:1,48'],
             ['email', 'lang:igniter.cart::default.checkout.label_email', 'sometimes|required|email:filter|max:96|unique:customers'],
-            ['telephone', 'lang:igniter.cart::default.checkout.label_telephone', ''],
+            ['telephone', 'lang:igniter.cart::default.checkout.label_telephone', 'integer'],
             ['comment', 'lang:igniter.cart::default.checkout.label_comment', 'max:500'],
             ['payment', 'lang:igniter.cart::default.checkout.label_payment_method', 'sometimes|required|alpha_dash'],
             ['terms_condition', 'lang:button_agree_terms', 'sometimes|integer'],
@@ -299,7 +299,7 @@ class Checkout extends BaseComponent
         if (Location::orderTypeIsDelivery()) {
             $namedRules[] = ['address_id', 'lang:igniter.cart::default.checkout.label_address', 'required|integer'];
             $namedRules[] = ['address.address_1', 'lang:igniter.cart::default.checkout.label_address_1', 'required|min:3|max:128'];
-            $namedRules[] = ['address.address_2', 'lang:igniter.cart::default.checkout.label_address_2', 'sometimes|min:3|max:128'];
+            $namedRules[] = ['address.address_2', 'lang:igniter.cart::default.checkout.label_address_2', 'min:3|max:128'];
             $namedRules[] = ['address.city', 'lang:igniter.cart::default.checkout.label_city', 'sometimes|min:2|max:128'];
             $namedRules[] = ['address.state', 'lang:igniter.cart::default.checkout.label_state', 'sometimes|max:128'];
             $namedRules[] = ['address.postcode', 'lang:igniter.cart::default.checkout.label_postcode', 'string'];

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -290,7 +290,7 @@ class Checkout extends BaseComponent
             ['first_name', 'lang:igniter.cart::default.checkout.label_first_name', 'required|between:1,48'],
             ['last_name', 'lang:igniter.cart::default.checkout.label_last_name', 'required|between:1,48'],
             ['email', 'lang:igniter.cart::default.checkout.label_email', 'sometimes|required|email:filter|max:96|unique:customers'],
-            ['telephone', 'lang:igniter.cart::default.checkout.label_telephone', 'integer'],
+            ['telephone', 'lang:igniter.cart::default.checkout.label_telephone', 'string'],
             ['comment', 'lang:igniter.cart::default.checkout.label_comment', 'max:500'],
             ['payment', 'lang:igniter.cart::default.checkout.label_payment_method', 'sometimes|required|alpha_dash'],
             ['terms_condition', 'lang:button_agree_terms', 'sometimes|integer'],
@@ -299,11 +299,11 @@ class Checkout extends BaseComponent
         if (Location::orderTypeIsDelivery()) {
             $namedRules[] = ['address_id', 'lang:igniter.cart::default.checkout.label_address', 'required|integer'];
             $namedRules[] = ['address.address_1', 'lang:igniter.cart::default.checkout.label_address_1', 'required|min:3|max:128'];
-            $namedRules[] = ['address.address_2', 'lang:igniter.cart::default.checkout.label_address_2', 'min:3|max:128'];
-            $namedRules[] = ['address.city', 'lang:igniter.cart::default.checkout.label_city', 'sometimes|min:2|max:128'];
-            $namedRules[] = ['address.state', 'lang:igniter.cart::default.checkout.label_state', 'sometimes|max:128'];
+            $namedRules[] = ['address.address_2', 'lang:igniter.cart::default.checkout.label_address_2', 'present|min:3|max:128'];
+            $namedRules[] = ['address.city', 'lang:igniter.cart::default.checkout.label_city', 'present|min:2|max:128'];
+            $namedRules[] = ['address.state', 'lang:igniter.cart::default.checkout.label_state', 'present|max:128'];
             $namedRules[] = ['address.postcode', 'lang:igniter.cart::default.checkout.label_postcode', 'string'];
-            $namedRules[] = ['address.country_id', 'lang:igniter.cart::default.checkout.label_country', 'sometimes|required|integer'];
+            $namedRules[] = ['address.country_id', 'lang:igniter.cart::default.checkout.label_country', 'present|required|integer'];
         }
 
         return $namedRules;

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -290,7 +290,7 @@ class Checkout extends BaseComponent
             ['first_name', 'lang:igniter.cart::default.checkout.label_first_name', 'required|between:1,48'],
             ['last_name', 'lang:igniter.cart::default.checkout.label_last_name', 'required|between:1,48'],
             ['email', 'lang:igniter.cart::default.checkout.label_email', 'sometimes|required|email:filter|max:96|unique:customers'],
-            ['telephone', 'lang:igniter.cart::default.checkout.label_telephone', 'string'],
+            ['telephone', 'lang:igniter.cart::default.checkout.label_telephone', 'regex:/^([0-9\s\-\+\(\)]*)$/i'],
             ['comment', 'lang:igniter.cart::default.checkout.label_comment', 'max:500'],
             ['payment', 'lang:igniter.cart::default.checkout.label_payment_method', 'sometimes|required|alpha_dash'],
             ['terms_condition', 'lang:button_agree_terms', 'sometimes|integer'],


### PR DESCRIPTION
- Telephone must be a number
- Address 2 removed sometimes: fix edge case  when  a customer with a saved address with empty address 2 try to make an order with address 2 fields hidden and the system keeps asking for address 2 to be at least 3 digit...