### PR TITLE
Add precheckout validation

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -125,11 +125,14 @@
         $(this.options.formSelector).prop('disabled', false)
     }
 
-    Checkout.prototype.onValidateCheckoutForm = function ($checkoutForm) {
+    Checkout.prototype.onValidateCheckoutForm = function ($checkoutForm, callbackFn) {
         $checkoutForm.request($checkoutForm.data('validateHandler'))
         .then((response) => {
             if (!response.error) {
-                this.completeCheckout($checkoutForm);
+                if (!callbackFn)
+                    this.completeCheckout($checkoutForm);
+                else
+                    callbackFn(response);
                 return;
             }
 

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -27,9 +27,9 @@
             .on('submit', this.options.formSelector, $.proxy(this.onSubmitCheckoutForm, this))
             .on('ajaxFail ajaxDone', this.options.formSelector, $.proxy(this.onFailCheckoutForm, this))
     }
-    
+
     Checkout.prototype.completeCheckout = function ($checkoutForm) {
-        $checkoutBtn = $('.checkout-btn');
+        var $checkoutBtn = $('.checkout-btn');
 
         var _event = jQuery.Event('submitCheckoutForm')
         $checkoutForm.trigger(_event)
@@ -110,12 +110,12 @@
     Checkout.prototype.onSubmitCheckoutForm = function (event) {
         var $checkoutForm = $(event.target),
             $checkoutBtn = $('.checkout-btn'),
-            $selectedPaymentMethod = this.$el.find(this.paymentInputSelector).is(':checked')
+            $selectedPaymentMethod = this.$el.find(this.paymentInputSelector + ':checked')
 
         $checkoutBtn.prop('disabled', true)
 
         event.preventDefault();
-        
+
         if ($selectedPaymentMethod && $selectedPaymentMethod.data('requirePrecheckoutValidation')) {
             this.onValidateCheckoutForm($checkoutForm);
             return;
@@ -127,14 +127,14 @@
     Checkout.prototype.onFailCheckoutForm = function (event) {
         $(this.options.formSelector).prop('disabled', false)
     }
-    
+
     Checkout.prototype.onValidateCheckoutForm = function ($checkoutForm) {
         var response = $checkoutForm.request($checkoutForm.data('validateHandler'));
         if (!response.error) {
             this.completeCheckout($checkoutForm);
             return;
         }
-        
+
         $.ti.flashMessage({ text: response.message, class: 'danger' });
     }
 

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -128,7 +128,7 @@
         $(this.options.formSelector).prop('disabled', false)
     }
     
-    Checkout.prototype.onValidateCheckoutForm = function (checkoutForm) {
+    Checkout.prototype.onValidateCheckoutForm = function ($checkoutForm) {
         var response = $checkoutForm.request($checkoutForm.data('validateHandler'));
         if (!response.error) {
             this.completeCheckout($checkoutForm);

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -29,12 +29,10 @@
     }
 
     Checkout.prototype.completeCheckout = function ($checkoutForm) {
-        var $checkoutBtn = $('.checkout-btn');
-
         var _event = jQuery.Event('submitCheckoutForm')
         $checkoutForm.trigger(_event)
         if (_event.isDefaultPrevented()) {
-            $checkoutBtn.prop('disabled', false)
+            this.$checkoutBtn.prop('disabled', false)
             return false;
         }
 
@@ -109,10 +107,9 @@
 
     Checkout.prototype.onSubmitCheckoutForm = function (event) {
         var $checkoutForm = $(event.target),
-            $checkoutBtn = $('.checkout-btn'),
             $selectedPaymentMethod = this.$el.find(this.paymentInputSelector + ':checked')
 
-        $checkoutBtn.prop('disabled', true)
+        this.$checkoutBtn.prop('disabled', true)
 
         event.preventDefault();
 
@@ -137,6 +134,7 @@
             }
 
             $.ti.flashMessage({ text: response.message, class: 'danger' });
+            this.$checkoutBtn.prop('disabled', false)
         });
     }
 

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -33,15 +33,26 @@
             .then((response) => {
                 if (!response.error) {
                     if (!callbackFn)
-                        $checkoutForm.request($checkoutForm.data('handler'))
+                        this.completeCheckout($checkoutForm);
                     else
                         callbackFn(response);
                     return;
                 }
 
-                $.ti.flashMessage({text: response.message, class: 'danger'});
+                $.ti.flashMessage({ text: response.message, class: 'danger' });
                 this.$checkoutBtn.prop('disabled', false)
             });
+    }
+
+    Checkout.prototype.completeCheckout = function ($checkoutForm) {
+        var _event = jQuery.Event('submitCheckoutForm')
+        $checkoutForm.trigger(_event)
+        if (_event.isDefaultPrevented()) {
+            this.$checkoutBtn.prop('disabled', false)
+            return false;
+        }
+
+        $checkoutForm.request($checkoutForm.data('handler'))
     }
 
     Checkout.prototype.confirmCheckout = function ($el) {
@@ -118,19 +129,12 @@
 
         event.preventDefault();
 
-        var _event = jQuery.Event('submitCheckoutForm')
-        $checkoutForm.trigger(_event)
-        if (_event.isDefaultPrevented()) {
-            this.$checkoutBtn.prop('disabled', false)
-            return false;
-        }
-
         if ($selectedPaymentMethod && $selectedPaymentMethod.data('requiresPreCheckoutValidation')) {
             this.validateCheckout($checkoutForm);
             return false;
         }
 
-        $checkoutForm.request($checkoutForm.data('handler'))
+        this.completeCheckout($checkoutForm);
     }
 
     Checkout.prototype.onFailCheckoutForm = function (event) {

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -29,7 +29,7 @@
     }
     
     Checkout.prototype.completeCheckout = function ($checkoutForm) {
-        $checkoutBtn = $('.checkout-btn'),
+        $checkoutBtn = $('.checkout-btn');
 
         var _event = jQuery.Event('submitCheckoutForm')
         $checkoutForm.trigger(_event)

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -129,13 +129,15 @@
     }
 
     Checkout.prototype.onValidateCheckoutForm = function ($checkoutForm) {
-        var response = $checkoutForm.request($checkoutForm.data('validateHandler'));
-        if (!response.error) {
-            this.completeCheckout($checkoutForm);
-            return;
-        }
+        $checkoutForm.request($checkoutForm.data('validateHandler'))
+        .then((response) => {
+            if (!response.error) {
+                this.completeCheckout($checkoutForm);
+                return;
+            }
 
-        $.ti.flashMessage({ text: response.message, class: 'danger' });
+            $.ti.flashMessage({ text: response.message, class: 'danger' });
+        });
     }
 
     Checkout.DEFAULTS = {

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -3,6 +3,7 @@
 namespace Igniter\Cart\Components;
 
 use Admin\Traits\ValidatesForm;
+use Event;
 use Exception;
 use Igniter\Cart\Classes\CartManager;
 use Igniter\Cart\Classes\OrderManager;

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -214,6 +214,8 @@ class Checkout extends BaseComponent
         try {
             $this->validatePostData($data);
 
+            Event::fire('igniter.cart.onConfirm', [$data]);
+
             $order = $this->getOrder();
             $this->orderManager->saveOrder($order, $data);
 
@@ -261,6 +263,8 @@ class Checkout extends BaseComponent
 
         try {
             $this->validatePostData($data);
+
+            Event::fire('igniter.cart.onValidate', [$data]);
 
             return [
                 'error' => false,

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -3,13 +3,13 @@
 namespace Igniter\Cart\Components;
 
 use Admin\Traits\ValidatesForm;
-use Event;
 use Exception;
 use Igniter\Cart\Classes\CartManager;
 use Igniter\Cart\Classes\OrderManager;
 use Igniter\Flame\Exception\ApplicationException;
 use Igniter\Local\Facades\Location;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Redirect;
 use Main\Facades\Auth;
 use System\Classes\BaseComponent;
@@ -215,8 +215,6 @@ class Checkout extends BaseComponent
         try {
             $this->validatePostData($data);
 
-            Event::fire('igniter.cart.onConfirm', [$data]);
-
             $order = $this->getOrder();
             $this->orderManager->saveOrder($order, $data);
 
@@ -264,8 +262,6 @@ class Checkout extends BaseComponent
 
         try {
             $this->validatePostData($data);
-
-            Event::fire('igniter.cart.onValidate', [$data]);
 
             return [
                 'error' => false,
@@ -321,6 +317,8 @@ class Checkout extends BaseComponent
         if ($order->isDeliveryType()) {
             $this->orderManager->validateDeliveryAddress(array_get($data, 'address', []));
         }
+
+        Event::fire('igniter.cart.onValidateCheckout', [$data]);
     }
 
     protected function createRules()

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -318,7 +318,7 @@ class Checkout extends BaseComponent
             $this->orderManager->validateDeliveryAddress(array_get($data, 'address', []));
         }
 
-        Event::fire('igniter.cart.onValidateCheckout', [$data]);
+        Event::fire('igniter.checkout.onValidate', [$data]);
     }
 
     protected function createRules()

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -211,19 +211,10 @@ class Checkout extends BaseComponent
 
         $data = $this->processDeliveryAddress($data);
 
-        $this->validateCheckoutSecurity();
-
         try {
-            $this->validate($data, $this->createRules(), [
-                'email.unique' => lang('igniter.cart::default.checkout.error_email_exists'),
-            ]);
+            $this->validatePostData($data);
 
             $order = $this->getOrder();
-
-            if ($order->isDeliveryType()) {
-                $this->orderManager->validateDeliveryAddress(array_get($data, 'address', []));
-            }
-
             $this->orderManager->saveOrder($order, $data);
 
             if (($redirect = $this->orderManager->processPayment($order, $data)) === FALSE)
@@ -268,18 +259,8 @@ class Checkout extends BaseComponent
         $data = post();
         $data = $this->processDeliveryAddress($data);
 
-        $this->validateCheckoutSecurity();
-
         try {
-            $this->validate($data, $this->createRules(), [
-                'email.unique' => lang('igniter.cart::default.checkout.error_email_exists'),
-            ]);
-
-            $order = $this->getOrder();
-
-            if ($order->isDeliveryType()) {
-                $this->orderManager->validateDeliveryAddress(array_get($data, 'address', []));
-            }
+            $this->validatePostData($data);
 
             return [
                 'error' => false,
@@ -320,6 +301,21 @@ class Checkout extends BaseComponent
         $this->cartManager->validateLocation();
 
         $this->cartManager->validateOrderTime();
+    }
+    
+    protected function validatePostData($data)
+    {
+        $this->validateCheckoutSecurity();
+
+        $this->validate($data, $this->createRules(), [
+            'email.unique' => lang('igniter.cart::default.checkout.error_email_exists'),
+        ]);
+
+        $order = $this->getOrder();
+
+        if ($order->isDeliveryType()) {
+            $this->orderManager->validateDeliveryAddress(array_get($data, 'address', []));
+        }        
     }
 
     protected function createRules()

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -302,7 +302,7 @@ class Checkout extends BaseComponent
 
         $this->cartManager->validateOrderTime();
     }
-    
+
     protected function validatePostData($data)
     {
         $this->validateCheckoutSecurity();
@@ -315,7 +315,7 @@ class Checkout extends BaseComponent
 
         if ($order->isDeliveryType()) {
             $this->orderManager->validateDeliveryAddress(array_get($data, 'address', []));
-        }        
+        }
     }
 
     protected function createRules()

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -262,7 +262,7 @@ class Checkout extends BaseComponent
 
         return $result;
     }
-    
+
     public function onValidate()
     {
         $data = post();
@@ -282,7 +282,7 @@ class Checkout extends BaseComponent
             }
             
             return [
-                'error' => false,  
+                'error' => false,
             ];
         }
         catch (Exception $ex) {

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -258,21 +258,10 @@ class Checkout extends BaseComponent
     public function onValidate()
     {
         $data = post();
+
         $data = $this->processDeliveryAddress($data);
 
-        try {
-            $this->validatePostData($data);
-
-            return [
-                'error' => false,
-            ];
-        }
-        catch (Exception $ex) {
-            return [
-                'error' => true,
-                'message' => $ex->getMessage(),
-            ];
-        }
+        $this->validatePostData($data);
     }
 
     protected function checkCheckoutSecurity()

--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -280,7 +280,7 @@ class Checkout extends BaseComponent
             if ($order->isDeliveryType()) {
                 $this->orderManager->validateDeliveryAddress(array_get($data, 'address', []));
             }
-            
+
             return [
                 'error' => false,
             ];

--- a/components/checkout/default.blade.php
+++ b/components/checkout/default.blade.php
@@ -2,6 +2,7 @@
     data-control="checkout"
     data-choose-payment-handler="{{ $choosePaymentEventHandler }}"
     data-delete-payment-handler="{{ $deletePaymentEventHandler }}"
+    data-validate-handler="{{ $validateCheckoutEventHandler }}"
     data-partial="checkoutForm"
 >
     @partial('@form')

--- a/components/checkout/form.blade.php
+++ b/components/checkout/form.blade.php
@@ -3,8 +3,6 @@
     'role' => 'form',
     'method' => 'POST',
     'data-handler' => $confirmCheckoutEventHandler,
-    'data-validate-handler' => $validateCheckoutEventHandler,
-
 ]) !!}
 
 @partial('@customer_fields')

--- a/components/checkout/form.blade.php
+++ b/components/checkout/form.blade.php
@@ -3,6 +3,8 @@
     'role' => 'form',
     'method' => 'POST',
     'data-handler' => $confirmCheckoutEventHandler,
+    'data-validate-handler' => $validateCheckoutEventHandler,
+
 ]) !!}
 
 @partial('@customer_fields')

--- a/components/checkout/payments.blade.php
+++ b/components/checkout/payments.blade.php
@@ -30,7 +30,7 @@
                                         value="{{ $paymentGateway->code }}"
                                         {!! $paymentIsSelected ? 'checked="checked"' : '' !!}
                                         {!! $paymentIsNotApplicable ? 'disabled="disabled"' : '' !!}
-                                        {!! $paymentGateway->requirePrecheckoutValidation() ? 'data-require-precheckout-validation="true"' : '' !!}
+                                        {!! $paymentGateway->requiresPreCheckoutValidation() ? 'data-requires-pre-checkout-validation="true"' : '' !!}
                                         autocomplete="off"
                                     />
                                     <label

--- a/components/checkout/payments.blade.php
+++ b/components/checkout/payments.blade.php
@@ -30,7 +30,7 @@
                                         value="{{ $paymentGateway->code }}"
                                         {!! $paymentIsSelected ? 'checked="checked"' : '' !!}
                                         {!! $paymentIsNotApplicable ? 'disabled="disabled"' : '' !!}
-                                        {!! $paymentGateway->requiresPreCheckoutValidation() ? 'data-requires-pre-checkout-validation="true"' : '' !!}
+                                        data-pre-validate-checkout="{{ $paymentGateway->completesPaymentOnClient() ? 'true' : 'false' }}"
                                         autocomplete="off"
                                     />
                                     <label

--- a/components/checkout/payments.blade.php
+++ b/components/checkout/payments.blade.php
@@ -30,6 +30,7 @@
                                         value="{{ $paymentGateway->code }}"
                                         {!! $paymentIsSelected ? 'checked="checked"' : '' !!}
                                         {!! $paymentIsNotApplicable ? 'disabled="disabled"' : '' !!}
+                                        {!! $paymentGateway->requirePrecheckoutValidation() ? 'data-require-precheckout-validation="true"' : '' !!}
                                         autocomplete="off"
                                     />
                                     <label


### PR DESCRIPTION
See also https://github.com/tastyigniter/ti-ext-payregister/pull/26 and https://github.com/tastyigniter/TastyIgniter/pull/844

@JamesThanna this is completely untested and probably buggy, but should give you a start in the right direction. Do you want to give it a test and see how it works for you? I can pick up any issues over the coming week and work with you to resolve them.

Still to do:

- [x] Refactor so onConfirm() and onValidate() dont repeat same logic
- [x] Test
- [ ] Apply to other payment gateways as required 