### PR TITLE
parseFloat() minQuantity Value to prevent string concatenation

### DIFF
--- a/assets/js/cartitem.js
+++ b/assets/js/cartitem.js
@@ -53,7 +53,7 @@
             oldValue = parseFloat($input.val())
 
         if ($button.data('operator') === 'plus') {
-            $input.val(oldValue + this.options.minQuantity)
+            $input.val(oldValue + parseFloat(this.options.minQuantity))
         } else {
             $input.val((oldValue > 0) ? oldValue - this.options.minQuantity : 0)
         }


### PR DESCRIPTION
I believe this only comes up if you're using a custom menu template and/or an extension like https://github.com/CupNoodles/ti-ext-pricebyweight.

However, JS `+` defaults to string concatenation if you pass it a decimal value like '1.00' or '.25' therefore as it stands, hitting the `+` button when the `minQuantity` or `step` field is set to '1.00' causes it to go from 1 to 11 to 111, etc.