### PR TITLE
Super minor bug fix for checkout payment radio buttons

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -60,7 +60,7 @@
         var self = this,
             $paymentToggle = $el.closest('[data-toggle="payments"]')
 
-        if ($paymentToggle.hasClass('in-progress') || $el.find(this.paymentInputSelector).is(':checked'))
+        if ($paymentToggle.hasClass('in-progress') || $el.find(this.paymentInputSelector).attr('checked'))
             return
 
         this.$checkoutBtn.prop('disabled', true)


### PR DESCRIPTION
is(":checked") no longer works as you expect it to in recent jQuery - using attr("checked") here instead

## How to Test

On the orange theme, if you have 2 or more payment methods, you'll see radio buttons on the left hand side of each one. On the main branch, clicking the labels succeeds in changing payment methods, but slightly annoyingly, clicking the radio button itself will not do anything. 

This update should fix the behavior so that it matches what the code is trying to do.