### PR TITLE
Fixed checkout proceeding without agreeing to terms and conditions

### DIFF
--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -388,7 +388,9 @@ class Checkout extends BaseComponent
             $namedRules = [];
 
         $namedRules[] = ['payment', 'lang:igniter.cart::default.checkout.label_payment_method', 'sometimes|required|alpha_dash'];
-        $namedRules[] = ['terms_condition', 'lang:button_agree_terms', 'sometimes|integer'];
+        if (strlen($this->getAgreeTermsPageSlug()) > 0) {
+            $namedRules[] = ['terms_condition', 'lang:button_agree_terms', 'required|integer'];
+        }
 
         return $namedRules;
     }

--- a/components/checkout/form.blade.php
+++ b/components/checkout/form.blade.php
@@ -43,7 +43,7 @@
     <div class="form-group">
         <div class="form-check">
             <input
-                id="terms-condition"
+                id="terms_condition"
                 type="checkbox"
                 name="terms_condition"
                 value="1"


### PR DESCRIPTION
Hi, I fixed a typo and the ruleset so that the terms and conditions should apply when the terms and conditions slug is set, please check. 
 