### PR TITLE
Fix limitCartItemOptions duplicating one option

### DIFF
--- a/components/cartbox/item_options.blade.php
+++ b/components/cartbox/item_options.blade.php
@@ -38,7 +38,7 @@
                             @partial('@item_option_'.$menuOption->display_type, [
                                 'index' => $index,
                                 'cartItem' => $cartItem,
-                                'optionValues' => $optionValues->sortBy('priority')->slice($limitCartItemOptionsValues-1),
+                                'optionValues' => $optionValues->sortBy('priority')->slice($limitCartItemOptionsValues),
                             ])
                         </div>
                         <button


### PR DESCRIPTION
Seems like an off-by-one error here. 
Checked and it's fixed by that oneliner