### PR TITLE
Critical bugfix: Query issue fixed for Number of Ordered Menu Items Dashboard Widget

### DIFF
--- a/src/Listeners/ExtendDashboardCards.php
+++ b/src/Listeners/ExtendDashboardCards.php
@@ -7,6 +7,7 @@ namespace Igniter\Cart\Listeners;
 use Igniter\Admin\DashboardWidgets\Statistics;
 use Igniter\Cart\Models\Order;
 use Igniter\System\Models\Settings;
+use Illuminate\Support\Facades\DB;
 
 class ExtendDashboardCards
 {
@@ -211,8 +212,9 @@ class ExtendDashboardCards
      */
     protected function getOrderMenuItemsCount(callable $callback): int
     {
+        $prefix = DB::getTablePrefix();
         $query = Order::query()
-            ->selectRaw('SUM(order_menus.quantity) as total_quantity')
+            ->selectRaw('SUM('.$prefix.'order_menus.quantity) as total_quantity')
             ->join('order_menus', 'orders.order_id', '=', 'order_menus.order_id')
             ->where('orders.status_id', '>', '0')
             ->where('orders.status_id', '!=', Settings::get('canceled_order_status'));


### PR DESCRIPTION
When on dashboard, we try to add Number of Ordered Menu Items Dashboard Widget, it gives query error which gives internal server error and all widgets are broken on the dashboard as rest of the widgets fails to load due to one failed widget. 
It starts loading properly when we reset the dashboard widgets
Error: 
```
SQL: select SUM(order_menus.quantity) as total_quantity from `ti_orders` inner join `ti_order_menus` on `ti_orders`.`order_id` = `ti_order_menus`.`order_id` where `ti_orders`.`status_id` > 0 and `ti_orders`.`status_id` != 9 and `created_at` between 2025-12-18 00:00:00 and 2026-01-16 00:00:00 limit 1
```