### PR TITLE
fix(cart): cast Menu::getMinimumQtyAttribute() return to int

### DIFF
--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -136,9 +136,9 @@ class Menu extends Model implements Buyable
         )->min('price') ?: 0;
     }
 
-    public function getMinimumQtyAttribute($value)
+    public function getMinimumQtyAttribute($value): int
     {
-        return $value ?: 1;
+        return (int)($value ?: 1);
     }
 
     public static function getDropdownOptions()

--- a/tests/Models/MenuTest.php
+++ b/tests/Models/MenuTest.php
@@ -65,6 +65,20 @@ it('return minimum_qty attribute', function(): void {
     expect($menu->minimum_qty)->toBe(2);
 });
 
+it('returns minimum_qty as an integer regardless of the stored value type', function(): void {
+    $menu = new Menu;
+
+    // Simulate a PDO driver that returns column values as strings (emulated prepares).
+    $menu->setRawAttributes(['minimum_qty' => '3']);
+    expect($menu->minimum_qty)->toBe(3);
+
+    $menu->setRawAttributes(['minimum_qty' => '0']);
+    expect($menu->minimum_qty)->toBe(1);
+
+    $menu->setRawAttributes(['minimum_qty' => null]);
+    expect($menu->minimum_qty)->toBe(1);
+});
+
 it('returns true when menu has options', function(): void {
     $menu = Menu::factory()->create();
     $menu->menu_options()->create(['option_id' => 1]);


### PR DESCRIPTION
## Problem

`Menu::getMinimumQtyAttribute()` shadows the `'minimum_qty' => 'integer'` cast and returns the raw attribute value. In Eloquent a classic `getXxxAttribute()` accessor takes precedence over a cast, so the cast never runs. On environments where PDO returns column values as strings (emulated prepared statements — the PDO_MySQL default), `$menu->minimum_qty` is therefore a string, which breaks strict scalar type hints downstream — notably `Igniter\Orange\Data\MenuItemData::$minimumQuantity` (typed `?int`) on the storefront menu page:

```
TypeError: Cannot assign string to property Igniter\Orange\Data\MenuItemData::$minimumQuantity of type ?int
```

Reported by a community member: https://flareapp.io/share/95JJ4a45

## Fix

Cast the accessor's return value to `int` and add a `: int` return type. Added a regression test covering string / `'0'` / `null` raw values.

## Note — same pattern elsewhere (not addressed here)

The same shape ("a `getXxxAttribute()` accessor shadows a numeric cast and can leak the raw — possibly string — value") exists in a few other models and is worth a follow-up:

- `Igniter\User\Models\User::getSalePermissionAttribute()` — shadows `sale_permission => integer`
- `Igniter\User\Models\UserGroup::getAutoAssignLimitAttribute()` — shadows `auto_assign_limit => integer` (reads `$this->attributes[...]` directly)
- `Igniter\Reservation\Models\Reservation::getDurationAttribute()` — shadows `duration => integer`
- `Igniter\Cart\Models\Concerns\Stockable::getStockQtyAttribute()` — shadows `stock_qty => integer` (lower risk: returns a `sum()`, which is numeric)

Only `minimum_qty` currently flows into a strict scalar type hint, so it's the only one throwing today; the rest are latent.