### PR TITLE
Add AbstractOrderType::allowsBookingAt() policy method

### DIFF
--- a/src/Classes/AbstractOrderType.php
+++ b/src/Classes/AbstractOrderType.php
@@ -90,4 +90,23 @@ abstract class AbstractOrderType implements OrderTypeInterface
 
         return $this->location->getOrderTimeRestriction($this->code);
     }
+
+    public function allowsBookingAt(?bool $isAsap = null): bool
+    {
+        if ($isAsap === null) {
+            return true;
+        }
+
+        $restriction = $this->getScheduleRestriction();
+
+        if ($isAsap === false && $restriction === static::ASAP_ONLY) {
+            return false;
+        }
+
+        if ($isAsap === true && $restriction === static::LATER_ONLY) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/tests/Classes/AbstractOrderTypeTest.php
+++ b/tests/Classes/AbstractOrderTypeTest.php
@@ -109,3 +109,35 @@ it('gets schedule restriction', function(): void {
     $this->location->shouldReceive('getOrderTimeRestriction')->with('test')->andReturn(60);
     expect($this->orderType->getScheduleRestriction())->toBe(60);
 });
+
+it('allows booking when isAsap is null', function(): void {
+    expect($this->orderType->allowsBookingAt())->toBeTrue();
+    expect($this->orderType->allowsBookingAt(null))->toBeTrue();
+});
+
+it('rejects later booking when restriction is ASAP_ONLY', function(): void {
+    $this->location->shouldReceive('getSettings')->with('checkout.limit_orders')->andReturn(false);
+    $this->location->shouldReceive('hasFutureOrder')->with('test')->andReturn(false);
+    $this->location->shouldReceive('getOrderTimeRestriction')->with('test')->andReturn(AbstractOrderType::ASAP_ONLY);
+
+    expect($this->orderType->allowsBookingAt(false))->toBeFalse();
+    expect($this->orderType->allowsBookingAt(true))->toBeTrue();
+});
+
+it('rejects asap booking when restriction is LATER_ONLY', function(): void {
+    $this->location->shouldReceive('getSettings')->with('checkout.limit_orders')->andReturn(false);
+    $this->location->shouldReceive('hasFutureOrder')->with('test')->andReturn(false);
+    $this->location->shouldReceive('getOrderTimeRestriction')->with('test')->andReturn(AbstractOrderType::LATER_ONLY);
+
+    expect($this->orderType->allowsBookingAt(true))->toBeFalse();
+    expect($this->orderType->allowsBookingAt(false))->toBeTrue();
+});
+
+it('allows both choices when there is no restriction', function(): void {
+    $this->location->shouldReceive('getSettings')->with('checkout.limit_orders')->andReturn(false);
+    $this->location->shouldReceive('hasFutureOrder')->with('test')->andReturn(false);
+    $this->location->shouldReceive('getOrderTimeRestriction')->with('test')->andReturn(0);
+
+    expect($this->orderType->allowsBookingAt(true))->toBeTrue();
+    expect($this->orderType->allowsBookingAt(false))->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Adds `AbstractOrderType::allowsBookingAt(?bool $isAsap = null): bool` — a single predicate that callers can use to validate a customer's ASAP-vs-Later choice against the order type's `getScheduleRestriction()`.

## Why

Today, the `ASAP_ONLY` / `LATER_ONLY` policy is encoded in `getScheduleRestriction()` but there's no public method that *applies* that policy. Callers (validation in `Location::checkOrderTime`, themes' fulfillment flows) have to re-implement the rule against the constants, which is what caused the bug where the Orange theme silently accepted "Later" bookings on an ASAP-only delivery location.

Centralising the check here:

- keeps the rule co-located with the data it reads (`getScheduleRestriction`)
- gives consumers a single API rather than scattered `=== ASAP_ONLY` comparisons
- covers both directions (ASAP_ONLY rejects Later, LATER_ONLY rejects ASAP)

## Behavior

| Input | `getScheduleRestriction()` | Result |
|---|---|---|
| `null` | any | `true` (back-compat — caller didn't supply the choice) |
| `false` (Later) | `ASAP_ONLY` | `false` |
| `true` (ASAP) | `LATER_ONLY` | `false` |
| anything else | anything else | `true` |

Returning `true` for `null` preserves back-compat for existing callers (admin order edits, API endpoints) that don't have a user-supplied ASAP/Later choice.

## Test plan

- [x] `it allows booking when isAsap is null` — null bypasses the check.
- [x] `it rejects later booking when restriction is ASAP_ONLY`.
- [x] `it rejects asap booking when restriction is LATER_ONLY`.
- [x] `it allows both choices when there is no restriction`.

## Follow-ups

Companion PRs to be filed against:
- `tastyigniter/ti-ext-local` — wire the parameter into `Location::checkOrderTime` and delegate to this method.
- `tastyigniter/ti-theme-orange` — hide the inapplicable radio and pass the choice through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)