### PR TITLE
feat: add conditional menu option visibility

### DIFF
--- a/database/migrations/2026_06_20_010000_create_menu_item_option_linked_values_table.php
+++ b/database/migrations/2026_06_20_010000_create_menu_item_option_linked_values_table.php
@@ -9,9 +9,10 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('menu_item_option_linked_values', function (Blueprint $table): void {
-            $table->unsignedInteger('menu_item_option_value_id');
             $table->unsignedInteger('menu_option_id');
-            $table->primary(['menu_item_option_value_id', 'menu_option_id']);
+            $table->unsignedInteger('menu_item_option_value_id');
+            $table->primary(['menu_option_id', 'menu_item_option_value_id']);
+            $table->index('menu_item_option_value_id');
         });
     }
 

--- a/database/migrations/2026_06_20_010000_create_menu_item_option_linked_values_table.php
+++ b/database/migrations/2026_06_20_010000_create_menu_item_option_linked_values_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('menu_item_option_linked_values', function (Blueprint $table): void {
+            $table->unsignedInteger('menu_item_option_value_id');
+            $table->unsignedInteger('menu_option_id');
+            $table->primary(['menu_item_option_value_id', 'menu_option_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('menu_item_option_linked_values');
+    }
+};

--- a/resources/lang/en/default.php
+++ b/resources/lang/en/default.php
@@ -471,6 +471,8 @@ return [
 
         'help_min_selected' => 'Minimum items to select from these options, set to 0 to ignore.',
         'help_max_selected' => 'Maximum items to select from these options, set to 0 to ignore.',
+        'label_linked_option_values' => 'Conditional On (Show When)',
+        'help_linked_option_values' => 'This option will only appear when one of the selected values above is chosen.',
         'help_menu_option' => 'Choose from the dropdown to assign a menu option to this menu item.',
 
         'alert_menu_option_not_attached' => 'Please select a menu option to assign.',

--- a/resources/models/menuitemoption.php
+++ b/resources/models/menuitemoption.php
@@ -29,6 +29,14 @@ $config['form']['fields'] = [
         'span' => 'right',
         'comment' => 'lang:igniter.cart::default.menu_options.help_max_selected',
     ],
+    'linked_option_value_ids' => [
+        'label' => 'lang:igniter.cart::default.menu_options.label_linked_option_values',
+        'type' => 'selectlist',
+        'mode' => 'checkbox',
+        'options' => 'getLinkedMenuOptionValueOptions',
+        'valueFrom' => 'linked_option_value_ids',
+        'comment' => 'lang:igniter.cart::default.menu_options.help_linked_option_values',
+    ],
     'menu_option_values' => [
         'type' => 'repeater',
         'form' => 'menuitemoptionvalue',

--- a/src/Models/MenuItemOption.php
+++ b/src/Models/MenuItemOption.php
@@ -69,9 +69,17 @@ class MenuItemOption extends Model
             'menu' => [Menu::class],
             'option' => [MenuOption::class],
         ],
+        'belongsToMany' => [
+            'linkedOptionValues' => [
+                MenuItemOptionValue::class,
+                'table' => 'menu_item_option_linked_values',
+                'foreignKey' => 'menu_option_id',
+                'otherKey' => 'menu_item_option_value_id',
+            ],
+        ],
     ];
 
-    public $appends = ['option_name', 'display_type'];
+    public $appends = ['option_name', 'display_type', 'linked_option_value_ids'];
 
     public $rules = [
         ['menu_id', 'igniter.cart::default.menus.label_menu_id', 'required|integer'],
@@ -82,7 +90,7 @@ class MenuItemOption extends Model
         ['max_selected', 'igniter.cart::default.menu_options.label_max_selected', 'integer|gte:min_selected'],
     ];
 
-    protected $purgeable = ['menu_option_values'];
+    protected $purgeable = ['menu_option_values', 'linked_option_value_ids'];
 
     public $with = ['option'];
 
@@ -168,5 +176,27 @@ class MenuItemOption extends Model
             'min_selected.max' => lang('igniter.cart::default.menu_options.error_min_selected_not_applicable'),
             'max_selected.max' => lang('igniter.cart::default.menu_options.error_max_selected_not_applicable'),
         ];
+    }
+
+    public function getLinkedOptionValueIdsAttribute(): array
+    {
+        return $this->linkedOptionValues()->pluck('menu_item_option_values.menu_option_value_id')->all();
+    }
+
+    public function getLinkedMenuOptionValueOptions(): array
+    {
+        $options = [];
+        $siblings = static::where('menu_id', $this->menu_id)
+            ->where('menu_option_id', '!=', $this->getKey())
+            ->with(['option', 'menu_option_values.option_value'])
+            ->get();
+
+        foreach ($siblings as $sibling) {
+            foreach ($sibling->menu_option_values as $value) {
+                $options[$value->menu_option_value_id] = $sibling->option_name.': '.$value->name;
+            }
+        }
+
+        return $options;
     }
 }

--- a/src/Models/MenuItemOption.php
+++ b/src/Models/MenuItemOption.php
@@ -178,10 +178,14 @@ class MenuItemOption extends Model
         ];
     }
 
-    public function getLinkedOptionValueIdsAttribute(): array
-    {
-        return $this->linkedOptionValues()->pluck('menu_item_option_values.menu_option_value_id')->all();
+public function getLinkedOptionValueIdsAttribute(): array
+{
+    if ($this->relationLoaded('linkedOptionValues')) {
+        return $this->linkedOptionValues->pluck('menu_option_value_id')->all();
     }
+
+    return $this->linkedOptionValues()->pluck('menu_option_value_id')->all();
+}
 
     public function getLinkedMenuOptionValueOptions(): array
     {

--- a/src/Models/MenuItemOption.php
+++ b/src/Models/MenuItemOption.php
@@ -190,11 +190,13 @@ public function getLinkedOptionValueIdsAttribute(): array
     public function getLinkedMenuOptionValueOptions(): array
     {
         $options = [];
-        $siblings = static::where('menu_id', $this->menu_id)
-            ->where('menu_option_id', '!=', $this->getKey())
-            ->with(['option', 'menu_option_values.option_value'])
-            ->get();
+        $query = static::where('menu_id', $this->menu_id);
 
+        if ($this->exists) {
+            $query->where($this->getKeyName(), '!=', $this->getKey());
+        }
+
+        $siblings = $query->with(['option', 'menu_option_values.option_value'])->get();
         foreach ($siblings as $sibling) {
             foreach ($sibling->menu_option_values as $value) {
                 $options[$value->menu_option_value_id] = $sibling->option_name.': '.$value->name;

--- a/src/Models/Observers/MenuItemOptionObserver.php
+++ b/src/Models/Observers/MenuItemOptionObserver.php
@@ -8,11 +8,18 @@ use Igniter\Cart\Models\MenuItemOption;
 
 class MenuItemOptionObserver
 {
+    public function deleting(MenuItemOption $menuItemOption): void
+    {
+        $menuItemOption->linkedOptionValues()->detach();
+    }
+
     public function saved(MenuItemOption $menuItemOption): void
     {
         $menuItemOption->restorePurgedValues();
 
-        if (array_key_exists('menu_option_values', $attributes = $menuItemOption->getAttributes())) {
+        $attributes = $menuItemOption->getAttributes();
+
+        if (array_key_exists('menu_option_values', $attributes)) {
             $menuItemOption->addMenuOptionValues(array_filter(array_map(function(array $value): array|false {
                 if (array_get($value, 'is_enabled')) {
                     unset($value['is_enabled']);
@@ -22,6 +29,12 @@ class MenuItemOptionObserver
 
                 return false;
             }, array_get($attributes, 'menu_option_values', []))));
+        }
+
+        if (array_key_exists('linked_option_value_ids', $attributes)) {
+            $menuItemOption->linkedOptionValues()->sync(
+                array_filter((array) array_get($attributes, 'linked_option_value_ids', []))
+            );
         }
     }
 }

--- a/tests/Models/MenuItemOptionTest.php
+++ b/tests/Models/MenuItemOptionTest.php
@@ -141,7 +141,7 @@ it('configures menu item option model correctly', function(): void {
         ->and($menuItemOption->getFillable())->toEqual([
             'option_id', 'menu_id', 'is_required', 'priority', 'min_selected', 'max_selected',
         ])
-        ->and($menuItemOption->getAppends())->toEqual(['option_name', 'display_type'])
+        ->and($menuItemOption->getAppends())->toEqual(['option_name', 'display_type', 'linked_option_value_ids'])
         ->and($menuItemOption->timestamps)->toBeTrue()
         ->and($menuItemOption->relation)->toEqual([
             'hasMany' => [
@@ -154,6 +154,14 @@ it('configures menu item option model correctly', function(): void {
             'belongsTo' => [
                 'menu' => [Menu::class],
                 'option' => [MenuOption::class],
+            ],
+            'belongsToMany' => [
+                'linkedOptionValues' => [
+                    MenuItemOptionValue::class,
+                    'table' => 'menu_item_option_linked_values',
+                    'foreignKey' => 'menu_option_id',
+                    'otherKey' => 'menu_item_option_value_id',
+                ],
             ],
         ])
         ->and($menuItemOption->rules)->toEqual([

--- a/tests/Models/Observers/MenuItemOptionObserverTest.php
+++ b/tests/Models/Observers/MenuItemOptionObserverTest.php
@@ -62,3 +62,33 @@ it('handles empty menu_option_values gracefully', function(): void {
 
     $this->observer->saved($this->menuItemOption);
 });
+
+it('syncs linked option values when linked_option_value_ids is present', function(): void {
+    $pivotBuilder = Mockery::mock();
+    $pivotBuilder->shouldReceive('sync')->with([101, 202])->once();
+
+    $attributes = [
+        'linked_option_value_ids' => [101, 202],
+    ];
+
+    $this->menuItemOption->shouldReceive('getAttributes')->andReturn($attributes);
+    $this->menuItemOption->shouldReceive('linkedOptionValues')->andReturn($pivotBuilder);
+
+    $this->observer->saved($this->menuItemOption);
+});
+
+it('skips syncing linked option values when linked_option_value_ids is absent', function(): void {
+    $this->menuItemOption->shouldReceive('getAttributes')->andReturn([]);
+    $this->menuItemOption->shouldNotReceive('linkedOptionValues');
+
+    $this->observer->saved($this->menuItemOption);
+});
+
+it('detaches linked option values when deleting', function(): void {
+    $pivotBuilder = Mockery::mock();
+    $pivotBuilder->shouldReceive('detach')->once();
+
+    $this->menuItemOption->shouldReceive('linkedOptionValues')->andReturn($pivotBuilder);
+
+    $this->observer->deleting($this->menuItemOption);
+});


### PR DESCRIPTION
## Summary
- Adds `menu_item_option_linked_values` pivot table linking parent option values to child menu item options
- Extends `MenuItemOption` with a `belongsToMany` relation, `linked_option_value_ids` appended attribute, and admin helper method for the selectlist
- Syncs/detaches linked values in `MenuItemOptionObserver` on save and delete
- Adds a `selectlist` form field in the admin menu option editor ("Conditional On")
- Adds language keys for the new field

## Test plan
- Run `php artisan igniter:up` to apply the migration
- Open a menu item in admin → edit any option → confirm "Conditional On (Show When)" multi-select appears with sibling option values
- Save → confirm rows written to `menu_item_option_linked_values`
- On the frontend, conditional option is hidden until the linked parent value is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)