### PR TITLE
Release v4.2.2

### DIFF
--- a/database/migrations/2026_06_20_010000_create_menu_item_option_linked_values_table.php
+++ b/database/migrations/2026_06_20_010000_create_menu_item_option_linked_values_table.php
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('menu_item_option_linked_values', function (Blueprint $table): void {
+        Schema::create('menu_item_option_linked_values', function(Blueprint $table): void {
             $table->unsignedInteger('menu_option_id');
             $table->unsignedInteger('menu_item_option_value_id');
             $table->primary(['menu_option_id', 'menu_item_option_value_id']);

--- a/database/migrations/2026_06_20_010000_create_menu_item_option_linked_values_table.php
+++ b/database/migrations/2026_06_20_010000_create_menu_item_option_linked_values_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('menu_item_option_linked_values', function (Blueprint $table): void {
+            $table->unsignedInteger('menu_option_id');
+            $table->unsignedInteger('menu_item_option_value_id');
+            $table->primary(['menu_option_id', 'menu_item_option_value_id']);
+            $table->index('menu_item_option_value_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('menu_item_option_linked_values');
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -253,15 +253,45 @@ parameters:
 			path: src/Models/Menu.php
 
 		-
+			message: '#^Access to an undefined property Igniter\\Cart\\Models\\MenuItemOption\:\:\$linkedOptionValues\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Models/MenuItemOption.php
+
+		-
 			message: '#^Access to an undefined property Igniter\\Cart\\Models\\MenuItemOption\:\:\$option\.$#'
 			identifier: property.notFound
 			count: 3
 			path: src/Models/MenuItemOption.php
 
 		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$menu_option_values\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Models/MenuItemOption.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$option_name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Models/MenuItemOption.php
+
+		-
+			message: '#^Call to an undefined method Igniter\\Cart\\Models\\MenuItemOption\:\:linkedOptionValues\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Models/MenuItemOption.php
+
+		-
 			message: '#^Call to an undefined method Igniter\\Cart\\Models\\MenuItemOption\:\:menu_option_values\(\)\.$#'
 			identifier: method.notFound
 			count: 2
+			path: src/Models/MenuItemOption.php
+
+		-
+			message: '#^Relation ''menu_option_values'' is not found in Igniter\\Cart\\Models\\MenuItemOption model\.$#'
+			identifier: larastan.relationExistence
+			count: 1
 			path: src/Models/MenuItemOption.php
 
 		-
@@ -299,6 +329,12 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: src/Models/MenuOptionValue.php
+
+		-
+			message: '#^Call to an undefined method Igniter\\Cart\\Models\\MenuItemOption\:\:linkedOptionValues\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: src/Models/Observers/MenuItemOptionObserver.php
 
 		-
 			message: '#^Call to an undefined method Igniter\\Cart\\Models\\Category\|Igniter\\Flame\\Database\\Builder\<Igniter\\Cart\\Models\\Menu\>\:\:detach\(\)\.$#'

--- a/resources/lang/en/default.php
+++ b/resources/lang/en/default.php
@@ -471,6 +471,8 @@ return [
 
         'help_min_selected' => 'Minimum items to select from these options, set to 0 to ignore.',
         'help_max_selected' => 'Maximum items to select from these options, set to 0 to ignore.',
+        'label_linked_option_values' => 'Conditional On (Show When)',
+        'help_linked_option_values' => 'This option will only appear when one of the selected values above is chosen.',
         'help_menu_option' => 'Choose from the dropdown to assign a menu option to this menu item.',
 
         'alert_menu_option_not_attached' => 'Please select a menu option to assign.',

--- a/resources/models/menuitemoption.php
+++ b/resources/models/menuitemoption.php
@@ -29,6 +29,14 @@ $config['form']['fields'] = [
         'span' => 'right',
         'comment' => 'lang:igniter.cart::default.menu_options.help_max_selected',
     ],
+    'linked_option_value_ids' => [
+        'label' => 'lang:igniter.cart::default.menu_options.label_linked_option_values',
+        'type' => 'selectlist',
+        'mode' => 'checkbox',
+        'options' => 'getLinkedMenuOptionValueOptions',
+        'valueFrom' => 'linked_option_value_ids',
+        'comment' => 'lang:igniter.cart::default.menu_options.help_linked_option_values',
+    ],
     'menu_option_values' => [
         'type' => 'repeater',
         'form' => 'menuitemoptionvalue',

--- a/src/Classes/OrderManager.php
+++ b/src/Classes/OrderManager.php
@@ -20,6 +20,7 @@ use Igniter\User\Models\Address;
 use Igniter\User\Models\Customer;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Request;
 
@@ -87,10 +88,13 @@ class OrderManager
         }
 
         if (!$order->exists) {
-            $order->save();
+            DB::transaction(function() use ($order): void {
+                $order->save();
+                $order->addOrderMenus($this->cart->content()->all());
+                $order->addOrderTotals($this->getCartTotals());
+            }, 3);
+
             $this->setCurrentOrderId($order->order_id);
-            $order->addOrderMenus($this->cart->content()->all());
-            $order->addOrderTotals($this->getCartTotals());
         }
 
         return $order;
@@ -218,10 +222,15 @@ class OrderManager
         $order->fill($data);
         $this->applyRequiredAttributes($order);
 
-        $order->saveQuietly();
+        DB::transaction(function() use ($order): void {
+            if ($order->exists) {
+                Order::whereKey($order->getKey())->lockForUpdate()->first();
+            }
 
-        $order->addOrderMenus($this->cart->content()->all());
-        $order->addOrderTotals($this->getCartTotals());
+            $order->saveQuietly();
+            $order->addOrderMenus($this->cart->content()->all());
+            $order->addOrderTotals($this->getCartTotals());
+        }, 3);
 
         Event::dispatch('igniter.checkout.afterSaveOrder', [$order]);
 

--- a/src/Models/MenuItemOption.php
+++ b/src/Models/MenuItemOption.php
@@ -178,14 +178,14 @@ class MenuItemOption extends Model
         ];
     }
 
-public function getLinkedOptionValueIdsAttribute(): array
-{
-    if ($this->relationLoaded('linkedOptionValues')) {
-        return $this->linkedOptionValues->pluck('menu_option_value_id')->all();
-    }
+    public function getLinkedOptionValueIdsAttribute(): array
+    {
+        if ($this->relationLoaded('linkedOptionValues')) {
+            return $this->linkedOptionValues->pluck('menu_option_value_id')->all();
+        }
 
-    return $this->linkedOptionValues()->pluck('menu_option_value_id')->all();
-}
+        return $this->linkedOptionValues()->pluck('menu_option_value_id')->all();
+    }
 
     public function getLinkedMenuOptionValueOptions(): array
     {

--- a/src/Models/MenuItemOption.php
+++ b/src/Models/MenuItemOption.php
@@ -69,9 +69,17 @@ class MenuItemOption extends Model
             'menu' => [Menu::class],
             'option' => [MenuOption::class],
         ],
+        'belongsToMany' => [
+            'linkedOptionValues' => [
+                MenuItemOptionValue::class,
+                'table' => 'menu_item_option_linked_values',
+                'foreignKey' => 'menu_option_id',
+                'otherKey' => 'menu_item_option_value_id',
+            ],
+        ],
     ];
 
-    public $appends = ['option_name', 'display_type'];
+    public $appends = ['option_name', 'display_type', 'linked_option_value_ids'];
 
     public $rules = [
         ['menu_id', 'igniter.cart::default.menus.label_menu_id', 'required|integer'],
@@ -82,7 +90,7 @@ class MenuItemOption extends Model
         ['max_selected', 'igniter.cart::default.menu_options.label_max_selected', 'integer|gte:min_selected'],
     ];
 
-    protected $purgeable = ['menu_option_values'];
+    protected $purgeable = ['menu_option_values', 'linked_option_value_ids'];
 
     public $with = ['option'];
 
@@ -168,5 +176,33 @@ class MenuItemOption extends Model
             'min_selected.max' => lang('igniter.cart::default.menu_options.error_min_selected_not_applicable'),
             'max_selected.max' => lang('igniter.cart::default.menu_options.error_max_selected_not_applicable'),
         ];
+    }
+
+public function getLinkedOptionValueIdsAttribute(): array
+{
+    if ($this->relationLoaded('linkedOptionValues')) {
+        return $this->linkedOptionValues->pluck('menu_option_value_id')->all();
+    }
+
+    return $this->linkedOptionValues()->pluck('menu_option_value_id')->all();
+}
+
+    public function getLinkedMenuOptionValueOptions(): array
+    {
+        $options = [];
+        $query = static::where('menu_id', $this->menu_id);
+
+        if ($this->exists) {
+            $query->where($this->getKeyName(), '!=', $this->getKey());
+        }
+
+        $siblings = $query->with(['option', 'menu_option_values.option_value'])->get();
+        foreach ($siblings as $sibling) {
+            foreach ($sibling->menu_option_values as $value) {
+                $options[$value->menu_option_value_id] = $sibling->option_name.': '.$value->name;
+            }
+        }
+
+        return $options;
     }
 }

--- a/src/Models/Observers/MenuItemOptionObserver.php
+++ b/src/Models/Observers/MenuItemOptionObserver.php
@@ -8,11 +8,18 @@ use Igniter\Cart\Models\MenuItemOption;
 
 class MenuItemOptionObserver
 {
+    public function deleting(MenuItemOption $menuItemOption): void
+    {
+        $menuItemOption->linkedOptionValues()->detach();
+    }
+
     public function saved(MenuItemOption $menuItemOption): void
     {
         $menuItemOption->restorePurgedValues();
 
-        if (array_key_exists('menu_option_values', $attributes = $menuItemOption->getAttributes())) {
+        $attributes = $menuItemOption->getAttributes();
+
+        if (array_key_exists('menu_option_values', $attributes)) {
             $menuItemOption->addMenuOptionValues(array_filter(array_map(function(array $value): array|false {
                 if (array_get($value, 'is_enabled')) {
                     unset($value['is_enabled']);
@@ -22,6 +29,12 @@ class MenuItemOptionObserver
 
                 return false;
             }, array_get($attributes, 'menu_option_values', []))));
+        }
+
+        if (array_key_exists('linked_option_value_ids', $attributes)) {
+            $menuItemOption->linkedOptionValues()->sync(
+                array_filter((array) array_get($attributes, 'linked_option_value_ids', []))
+            );
         }
     }
 }

--- a/tests/Models/MenuItemOptionTest.php
+++ b/tests/Models/MenuItemOptionTest.php
@@ -141,7 +141,7 @@ it('configures menu item option model correctly', function(): void {
         ->and($menuItemOption->getFillable())->toEqual([
             'option_id', 'menu_id', 'is_required', 'priority', 'min_selected', 'max_selected',
         ])
-        ->and($menuItemOption->getAppends())->toEqual(['option_name', 'display_type'])
+        ->and($menuItemOption->getAppends())->toEqual(['option_name', 'display_type', 'linked_option_value_ids'])
         ->and($menuItemOption->timestamps)->toBeTrue()
         ->and($menuItemOption->relation)->toEqual([
             'hasMany' => [
@@ -154,6 +154,14 @@ it('configures menu item option model correctly', function(): void {
             'belongsTo' => [
                 'menu' => [Menu::class],
                 'option' => [MenuOption::class],
+            ],
+            'belongsToMany' => [
+                'linkedOptionValues' => [
+                    MenuItemOptionValue::class,
+                    'table' => 'menu_item_option_linked_values',
+                    'foreignKey' => 'menu_option_id',
+                    'otherKey' => 'menu_item_option_value_id',
+                ],
             ],
         ])
         ->and($menuItemOption->rules)->toEqual([

--- a/tests/Models/MenuItemOptionTest.php
+++ b/tests/Models/MenuItemOptionTest.php
@@ -130,6 +130,76 @@ it('validates min_selected and max_selected rules for select display type', func
         ->and($menuItemOption->getValidationMessages())->toHaveKeys(['min_selected.max', 'max_selected.max']);
 });
 
+it('returns linked option value ids from loaded relation', function(): void {
+    $menu = Menu::factory()->create();
+    $menuItemOption = MenuItemOption::factory()->for($menu, 'menu')->create();
+    $linkedValue = MenuItemOptionValue::factory()
+        ->for(MenuItemOption::factory()->for($menu, 'menu'), 'menu_option')
+        ->create();
+
+    $menuItemOption->linkedOptionValues()->attach($linkedValue->getKey());
+    $menuItemOption->load('linkedOptionValues');
+
+    expect($menuItemOption->linked_option_value_ids)->toBe([$linkedValue->getKey()]);
+});
+
+it('returns linked option value ids from database when relation is not loaded', function(): void {
+    $menu = Menu::factory()->create();
+    $menuItemOption = MenuItemOption::factory()->for($menu, 'menu')->create();
+    $linkedValue = MenuItemOptionValue::factory()
+        ->for(MenuItemOption::factory()->for($menu, 'menu'), 'menu_option')
+        ->create();
+
+    $menuItemOption->linkedOptionValues()->attach($linkedValue->getKey());
+    $menuItemOption->unsetRelation('linkedOptionValues');
+
+    expect($menuItemOption->linked_option_value_ids)->toBe([$linkedValue->getKey()]);
+});
+
+it('returns linked menu option value options from sibling options on the same menu', function(): void {
+    $menu = Menu::factory()->create();
+    $siblingOption = MenuOption::factory()->create(['option_name' => 'Size']);
+    $siblingMenuItemOption = MenuItemOption::factory()
+        ->for($menu, 'menu')
+        ->for($siblingOption, 'option')
+        ->create();
+    $optionValue = MenuOptionValue::factory()->for($siblingOption, 'option')->create(['name' => 'Large']);
+    $menuItemOptionValue = MenuItemOptionValue::factory()
+        ->for($siblingMenuItemOption, 'menu_option')
+        ->for($optionValue, 'option_value')
+        ->create();
+    $currentMenuItemOption = MenuItemOption::factory()
+        ->for($menu, 'menu')
+        ->for(MenuOption::factory()->create(['option_name' => 'Topping']), 'option')
+        ->create();
+
+    $options = $currentMenuItemOption->getLinkedMenuOptionValueOptions();
+
+    expect($options)->toBe([
+        $menuItemOptionValue->getKey() => 'Size: Large',
+    ]);
+});
+
+it('includes all menu options when getting linked menu option value options for unsaved model', function(): void {
+    $menu = Menu::factory()->create();
+    $menuOption = MenuOption::factory()->create(['option_name' => 'Size']);
+    $menuItemOption = MenuItemOption::factory()
+        ->for($menu, 'menu')
+        ->for($menuOption, 'option')
+        ->create();
+    $optionValue = MenuOptionValue::factory()->for($menuOption, 'option')->create(['name' => 'Large']);
+    $menuItemOptionValue = MenuItemOptionValue::factory()
+        ->for($menuItemOption, 'menu_option')
+        ->for($optionValue, 'option_value')
+        ->create();
+
+    $options = (new MenuItemOption(['menu_id' => $menu->getKey()]))->getLinkedMenuOptionValueOptions();
+
+    expect($options)->toBe([
+        $menuItemOptionValue->getKey() => 'Size: Large',
+    ]);
+});
+
 it('configures menu item option model correctly', function(): void {
     $menuItemOption = new MenuItemOption;
 

--- a/tests/Models/Observers/MenuItemOptionObserverTest.php
+++ b/tests/Models/Observers/MenuItemOptionObserverTest.php
@@ -62,3 +62,33 @@ it('handles empty menu_option_values gracefully', function(): void {
 
     $this->observer->saved($this->menuItemOption);
 });
+
+it('syncs linked option values when linked_option_value_ids is present', function(): void {
+    $pivotBuilder = Mockery::mock();
+    $pivotBuilder->shouldReceive('sync')->with([101, 202])->once();
+
+    $attributes = [
+        'linked_option_value_ids' => [101, 202],
+    ];
+
+    $this->menuItemOption->shouldReceive('getAttributes')->andReturn($attributes);
+    $this->menuItemOption->shouldReceive('linkedOptionValues')->andReturn($pivotBuilder);
+
+    $this->observer->saved($this->menuItemOption);
+});
+
+it('skips syncing linked option values when linked_option_value_ids is absent', function(): void {
+    $this->menuItemOption->shouldReceive('getAttributes')->andReturn([]);
+    $this->menuItemOption->shouldNotReceive('linkedOptionValues');
+
+    $this->observer->saved($this->menuItemOption);
+});
+
+it('detaches linked option values when deleting', function(): void {
+    $pivotBuilder = Mockery::mock();
+    $pivotBuilder->shouldReceive('detach')->once();
+
+    $this->menuItemOption->shouldReceive('linkedOptionValues')->andReturn($pivotBuilder);
+
+    $this->observer->deleting($this->menuItemOption);
+});


### PR DESCRIPTION
This release adds conditional menu option visibility and resolves a deadlock issue during concurrent checkouts.

## Added

- Support for conditional visibility of menu options, allowing options to be shown or hidden based on defined conditions

## Fixed

- Prevented deadlock errors occurring on order totals during concurrent checkout sessions