### PR TITLE
fix(checkout): apply new payment method fee immediately on selection

### DIFF
--- a/src/CartCondition.php
+++ b/src/CartCondition.php
@@ -107,6 +107,9 @@ abstract class CartCondition implements Arrayable, Jsonable
     public function apply($subTotal)
     {
         if ($this->beforeApply() === false) {
+            $this->passed = false;
+            $this->calculatedValue = 0;
+
             return $subTotal;
         }
 

--- a/src/CartConditions/PaymentFee.php
+++ b/src/CartConditions/PaymentFee.php
@@ -32,7 +32,7 @@ class PaymentFee extends CartCondition
             return false;
         }
 
-        if (is_null($this->paymentModel)) {
+        if (is_null($this->paymentModel) || $this->paymentModel->code !== $paymentCode) {
             $this->paymentModel = Payment::whereCode($paymentCode)->first();
         }
 

--- a/src/Classes/OrderManager.php
+++ b/src/Classes/OrderManager.php
@@ -288,12 +288,13 @@ class OrderManager
 
         $order->total_items = $this->cart->count();
         $order->cart = $this->cart->content();
-        $order->order_total = $this->cart->total();
 
         $paymentCode = $this->getCurrentPaymentCode();
-        $order->payment = $order->order_total > 0 ? $paymentCode : '';
+        $order->payment = $this->cart->total() > 0 ? $paymentCode : '';
 
         $this->applyCurrentPaymentFee($order->payment);
+
+        $order->order_total = $this->cart->total();
 
         $order->ip_address = Request::getClientIp();
     }


### PR DESCRIPTION
## Problem

Switching payment methods during checkout didn't apply the new method's fee until the page was fully refreshed, and a previously-applied fee could linger after switching to a method with no fee.

Root causes:
- `PaymentFee::beforeApply()` cached the resolved `Payment` model on first use and never refreshed it when the selected code changed within the same request.
- `CartCondition::apply()` left `passed`/`calculatedValue` stale when `beforeApply()` opted out, so a previously-applied condition kept reporting itself as applied with its old value.
- `OrderManager::applyRequiredAttributes()` computed `order_total` before the fee condition was applied, so the stored total could be out of sync with the selected payment method.

## Fix

- Refetch the `Payment` model whenever the metadata code changes, not just when it's null.
- Reset `passed`/`calculatedValue` when a condition opts out via `beforeApply()`, so stale state doesn't persist.
- Compute `order_total` after the fee condition is applied.

Existing test suite passes (`vendor/bin/pest`), including `PaymentFeeTest`, `CartConditionTest`, `CartTest`, and `OrderManagerTest`.