### PR TITLE
fix(order): generate invoice after payment processing

### DIFF
--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -297,6 +297,12 @@ class Order extends Model
             $this->processed = true;
             $this->saveQuietly();
 
+            // saveQuietly() bypasses the HasInvoice saved listener,
+            // so generate the invoice explicitly.
+            if ($this->isPaymentProcessed() && !$this->hasInvoice()) {
+                $this->generateInvoice();
+            }
+
             OrderPaymentProcessedEvent::dispatch($this);
         }
 

--- a/tests/Models/OrderTest.php
+++ b/tests/Models/OrderTest.php
@@ -249,11 +249,26 @@ it('marks order as canceled correctly', function(): void {
 });
 
 it('marks order payment as processed correctly', function(): void {
-    Event::fake();
+    Event::fake([
+        OrderBeforePaymentProcessedEvent::class,
+        OrderPaymentProcessedEvent::class,
+    ]);
 
-    $order = Order::factory()->create();
+    $order = Order::factory()->create([
+        'processed' => false,
+        'invoice_date' => null,
+        'invoice_prefix' => null,
+    ]);
 
-    expect($order->markAsPaymentProcessed())->toBeTrue();
+    expect($order->hasInvoice())->toBeFalse()
+        ->and($order->markAsPaymentProcessed())->toBeTrue();
+
+    $order->refresh();
+
+    expect($order->isPaymentProcessed())->toBeTrue()
+        ->and($order->hasInvoice())->toBeTrue()
+        ->and($order->invoice_number)->not->toBeNull();
+
     Event::assertDispatched(OrderBeforePaymentProcessedEvent::class);
     Event::assertDispatched(OrderPaymentProcessedEvent::class);
 });


### PR DESCRIPTION
## Summary

- Explicitly generate the internal invoice after an order is marked as payment processed.
- Add regression coverage for the invoice number and invoice state.
- Keep invoice generation before OrderPaymentProcessedEvent is dispatched.

## Root cause

Commit ce2b7cd changed save() to saveQuietly(). That suppresses the HasInvoice saved listener, leaving processed orders without invoice_date and invoice_prefix.

