### PR TITLE
Fix null admin user in status workflow middleware

### DIFF
--- a/src/Http/Middleware/InjectStatusWorkflow.php
+++ b/src/Http/Middleware/InjectStatusWorkflow.php
@@ -43,7 +43,7 @@ class InjectStatusWorkflow
         return $enableWorkflow
             && $request->isMethod('GET')
             && $request->route()?->getController() instanceof AdminController
-            && (!$limitUsers || in_array(AdminAuth::getUser()->getKey(), $limitUsers));
+            && (!$limitUsers || in_array(AdminAuth::getUser()?->getKey(), $limitUsers));
     }
 
     protected function renderOrderWorkflowView(): string


### PR DESCRIPTION
# Fix null admin user in status workflow middleware

## Summary

This PR prevents a 500 error in `InjectStatusWorkflow` when no admin user is authenticated.

## Problem

`shouldInjectOrderWorkflow()` currently calls:

```php
AdminAuth::getUser()->getKey()
```

When an unauthenticated user visits an admin route such as `/admin/login`, `AdminAuth::getUser()` can return `null`.

This results in:

```text
Call to a member function getKey() on null
```

and causes the admin login page to return a 500 error.

This is especially noticeable after clearing browser cookies or the existing admin session.

## Fix

Use PHP's null-safe operator when retrieving the admin user key:

```php
AdminAuth::getUser()?->getKey()
```

This keeps the existing workflow and user-limiting logic unchanged while preventing the exception when no admin user is authenticated.

## Changes

* Make the admin user lookup null-safe in `InjectStatusWorkflow`.
* No changes to the existing status workflow behaviour for authenticated admin users.

## Tested

* Admin login page loads correctly without an existing session.
* Status workflow continues to work for authenticated admin users.
